### PR TITLE
Project details form: Fix emphasized text

### DIFF
--- a/hymaintenance/high_ui/templates/high_ui/forms/add_project.html
+++ b/hymaintenance/high_ui/templates/high_ui/forms/add_project.html
@@ -94,9 +94,9 @@
                             {% endfor %}
                         </div>
                         <div class="help help-activation">
-                            <span class='activation-active'>Ce compteur sera <span class="duration">visible par les managers</span> du projet, et <span class="duration">utilisable par les intervenants Hybird</span> dans les tableaux de bord et pour enregistrer des demandes.</span>
-                            <span class='activation-hidden'>Ce compteur sera <span class="duration">invisible aux managers</span>, mais <span class="duration">utilisable par les intervenants Hybird</span> dans les tableaux de bord et pour enregistrer des demandes.</span>
-                            <span class='activation-inactive'>Ce compteur sera <span class="duration">désactivé</span> pour ce projet.</span>
+                            <span class='activation-active'>Ce compteur sera <em>visible par les managers</em> du projet, et <em>utilisable par les intervenants Hybird</em> dans les tableaux de bord et pour enregistrer des demandes.</span>
+                            <span class='activation-hidden'>Ce compteur sera <em>invisible aux managers</em>, mais <em>utilisable par les intervenants Hybird</em> dans les tableaux de bord et pour enregistrer des demandes.</span>
+                            <span class='activation-inactive'>Ce compteur sera <em>désactivé</em> pour ce projet.</span>
                         </div>
 
                         <div class="form-row row-counter-type {% if form.contract1_total_type.errors %}form-error{% endif %}">
@@ -137,8 +137,8 @@
                         </div>
 
                         <div class="help help-credit">
-                            <span class="counter-total">Ce compteur affichera le <span class="duration">total du temps passé</span> sur les demandes enregistrées par les intervenants Hybird.</span>
-                            <span class="counter-credit">Ce compteur affichera le <span class="duration">temps restant disponible</span> sur les heures <span class="duration">de {{maintenance_types.0.name}} créditées</span>, et qui sera consommé par les intervenants Hybird en enregistrant des demandes.</span>
+                            <span class="counter-total">Ce compteur affichera le <em>total du temps passé</em> sur les demandes enregistrées par les intervenants Hybird.</span>
+                            <span class="counter-credit">Ce compteur affichera le <em>temps restant disponible</em> sur les heures <em>de {{maintenance_types.0.name}} créditées</em>, et qui sera consommé par les intervenants Hybird en enregistrant des demandes.</span>
                         </div>
                     </div>
 
@@ -169,9 +169,9 @@
                             {% endfor %}
                         </div>
                         <div class="help help-activation">
-                            <span class='activation-active'>Ce compteur sera <span class="duration">visible par les managers</span> du projet, et <span class="duration">utilisable par les intervenants Hybird</span> dans les tableaux de bord et pour enregistrer des demandes.</span>
-                            <span class='activation-hidden'>Ce compteur sera <span class="duration">invisible aux managers</span>, mais <span class="duration">utilisable par les intervenants Hybird</span> dans les tableaux de bord et pour enregistrer des demandes.</span>
-                            <span class='activation-inactive'>Ce compteur sera <span class="duration">désactivé</span> pour ce projet.</span>
+                            <span class='activation-active'>Ce compteur sera <em>visible par les managers</em> du projet, et <em>utilisable par les intervenants Hybird</em> dans les tableaux de bord et pour enregistrer des demandes.</span>
+                            <span class='activation-hidden'>Ce compteur sera <em>invisible aux managers</em>, mais <em>utilisable par les intervenants Hybird</em> dans les tableaux de bord et pour enregistrer des demandes.</span>
+                            <span class='activation-inactive'>Ce compteur sera <em>désactivé</em> pour ce projet.</span>
                         </div>
 
                         <div class="form-row row-counter-type {% if form.contract2_total_type.errors %}form-error{% endif %}">
@@ -212,8 +212,8 @@
                         </div>
 
                         <div class="help help-credit">
-                            <span class="counter-total">Ce compteur affichera le <span class="duration">total du temps passé</span> sur les demandes enregistrées par les intervenants Hybird.</span>
-                            <span class="counter-credit">Ce compteur affichera le <span class="duration">temps restant disponible</span> sur les heures <span class="duration">de {{maintenance_types.1.name}} créditées</span>, et qui sera consommé par les intervenants Hybird en enregistrant des demandes.</span>
+                            <span class="counter-total">Ce compteur affichera le <em>total du temps passé</em> sur les demandes enregistrées par les intervenants Hybird.</span>
+                            <span class="counter-credit">Ce compteur affichera le <em>temps restant disponible</em> sur les heures <em>de {{maintenance_types.1.name}} créditées</em>, et qui sera consommé par les intervenants Hybird en enregistrant des demandes.</span>
                         </div>
                     </div>
 
@@ -244,9 +244,9 @@
                             {% endfor %}
                         </div>
                         <div class="help help-activation">
-                            <span class='activation-active'>Ce compteur sera <span class="duration">visible par les managers</span> du projet, et <span class="duration">utilisable par les intervenants Hybird</span> dans les tableaux de bord et pour enregistrer des demandes.</span>
-                            <span class='activation-hidden'>Ce compteur sera <span class="duration">invisible aux managers</span>, mais <span class="duration">utilisable par les intervenants Hybird</span> dans les tableaux de bord et pour enregistrer des demandes.</span>
-                            <span class='activation-inactive'>Ce compteur sera <span class="duration">désactivé</span> pour ce projet.</span>
+                            <span class='activation-active'>Ce compteur sera <em>visible par les managers</em> du projet, et <em>utilisable par les intervenants Hybird</em> dans les tableaux de bord et pour enregistrer des demandes.</span>
+                            <span class='activation-hidden'>Ce compteur sera <em>invisible aux managers</em>, mais <em>utilisable par les intervenants Hybird</em> dans les tableaux de bord et pour enregistrer des demandes.</span>
+                            <span class='activation-inactive'>Ce compteur sera <em>désactivé</em> pour ce projet.</span>
                         </div>
 
                         <div class="form-row row-counter-type {% if form.contract3_total_type.errors %}form-error{% endif %}">
@@ -287,8 +287,8 @@
                         </div>
 
                         <div class="help help-credit">
-                            <span class="counter-total">Ce compteur affichera le <span class="duration">total du temps passé</span> sur les demandes enregistrées par les intervenants Hybird.</span>
-                            <span class="counter-credit">Ce compteur affichera le <span class="duration">temps restant disponible</span> sur les heures <span class="duration">de {{maintenance_types.2.name}} créditées</span>, et qui sera consommé par les intervenants Hybird en enregistrant des demandes.</span>
+                            <span class="counter-total">Ce compteur affichera le <em>total du temps passé</em> sur les demandes enregistrées par les intervenants Hybird.</span>
+                            <span class="counter-credit">Ce compteur affichera le <em>temps restant disponible</em> sur les heures <em>de {{maintenance_types.2.name}} créditées</em>, et qui sera consommé par les intervenants Hybird en enregistrant des demandes.</span>
                         </div>
                     </div>
 


### PR DESCRIPTION
The form still used the older mockups style which doesn't match the current coded html/css.