### PR TITLE
Fix header contracts display in 2 forms

### DIFF
--- a/hymaintenance/high_ui/templates/high_ui/forms/add_consumer.html
+++ b/hymaintenance/high_ui/templates/high_ui/forms/add_consumer.html
@@ -25,7 +25,7 @@
         {% for contract in contracts %}
         <div class="dashboard-item">
             <span class="dashboard-title">{{contract.maintenance_type.label_for_company_detailview}}</span>
-            <span class="dashboard-value">{% pretty_print_minutes contract.get_number_remaining_minutes %} / {{contract.get_number_contract_hours}}h</span>
+            <span class="dashboard-value">{% pretty_print_contract_counter contract %}</span>
         </div>
         {% endfor %}
 

--- a/hymaintenance/high_ui/templates/high_ui/forms/add_issue.html
+++ b/hymaintenance/high_ui/templates/high_ui/forms/add_issue.html
@@ -23,7 +23,7 @@
         {% for contract in contracts %}
         <div class="dashboard-item">
             <span class="dashboard-title">{{contract.maintenance_type.label_for_company_detailview}}</span>
-            <span class="dashboard-value">{% pretty_print_minutes contract.get_number_remaining_minutes %} / {{contract.get_number_contract_hours}}h</span>
+            <span class="dashboard-value">{% pretty_print_contract_counter contract %}</span>
         </div>
         {% endfor %}
 

--- a/hymaintenance/high_ui/templates/high_ui/forms/add_user.html
+++ b/hymaintenance/high_ui/templates/high_ui/forms/add_user.html
@@ -25,7 +25,7 @@
         {% for contract in contracts %}
         <div class="dashboard-item">
             <span class="dashboard-title">{{contract.maintenance_type.label_for_company_detailview}}</span>
-            <span class="dashboard-value">{% pretty_print_minutes contract.get_number_remaining_minutes %} / {{contract.get_number_contract_hours}}h</span>
+            <span class="dashboard-value">{% pretty_print_contract_counter contract %}</span>
         </div>
         {% endfor %}
 

--- a/hymaintenance/high_ui/views.py
+++ b/hymaintenance/high_ui/views.py
@@ -165,6 +165,8 @@ class CreateViewWithCompany(CreateView):
     def get_context_data(self, **kwargs):
         context = super(CreateViewWithCompany, self).get_context_data(**kwargs)
         context['company'] = self.company
+        contracts = MaintenanceContract.objects.filter(company=self.company)
+        context['contracts'] = contracts
         return context
 
     def get_success_url(self):
@@ -178,10 +180,6 @@ class IssueCreateView(LoginRequiredMixin, CreateViewWithCompany):
     def get_context_data(self, **kwargs):
         context = super(IssueCreateView, self).get_context_data(**kwargs)
         context['channels'] = IncomingChannel.objects.all()
-
-        contracts = MaintenanceContract.objects.filter(company=self.company)
-        context['contracts'] = contracts
-
         return context
 
 


### PR DESCRIPTION
Fix the "create user" forms and "create issue" form header:
- The contracts text was using the old minutes remaining label, even in cases when the activity wasn't of the "Available total time" type.
- The `contracts` data used in the template was missing from the context data