### PR TITLE
Mockups: add "edit operator list" forms

### DIFF
--- a/mockups/css/edit-operators.css
+++ b/mockups/css/edit-operators.css
@@ -1,0 +1,94 @@
+.checkbox-list .item-name {
+    text-transform: none;
+    font-size: 13px;
+    font-weight: 600;
+    color: #525252;
+}
+
+.checkbox-list .item-description {
+    text-transform: uppercase;
+    font-weight: 600;
+    font-size: 11px;
+    color: #7c7c7c;
+}
+
+.list-intro {
+    line-height: 140%;
+}
+
+.form-group .group-title-container {
+    border: none;
+    margin-bottom: 0;
+}
+
+.form-group .group-title {
+    font-size: 13px;
+    cursor: pointer;
+}
+
+.form-group-collapsable {
+    position: relative;
+}
+
+.form-group-collapsable .group-title {
+    padding-left: 20px;
+}
+
+.form-group-collapsable .group-title::before {
+    content: "";
+    top: 4px;
+    left: 2px;
+    position: absolute;
+    width: 0;
+    height: 0;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top-width: 8px;
+    border-top-style: solid;
+    border-top-color: #666;
+    transition: transform ease-in-out 0.1s, border-top-color ease-in-out 0.3s;
+}
+
+.form-group-collapsable .form-group-collapsable-content {
+    max-height: 300px;
+    transition: max-height 0.3s ease-in-out;
+}
+
+form + form {
+    margin-top: 15px;
+    border-top: 1px solid #ccc;
+    padding-top: 15px;
+}
+
+.form-intro {
+    padding-top: 15px;
+}
+
+.form-footer {
+    max-height: 70px;
+    overflow: hidden;
+    transition: max-height 0.3s ease-in-out,
+                visibility 0.3s ease-in-out,
+                margin-top 0.3s ease-in-out,
+                padding-top 0.3s ease-in-out;
+}
+
+.form-group-collapsable.form-group-collapsed + .form-footer {
+    max-height: 0;
+    margin-top: 0;
+    padding-top: 0;
+    visibility: hidden;
+}
+
+.form-group-collapsable.form-group-collapsed .form-group-collapsable-content {
+    max-height: 0;
+}
+
+.form-group-collapsable.form-group-collapsed .group-title::before {
+    transform: rotate(-90deg);
+    border-top-color: #aaa;
+}
+
+.form-group.reactivate-form {
+    margin-top: 10px;
+}

--- a/mockups/edit-operators.html
+++ b/mockups/edit-operators.html
@@ -1,0 +1,273 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Maintenance Hybird &mdash; Nouvelle demande de Laforêt</title>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="css/normalize.css" />
+<link rel="stylesheet" href="css/style.css" />
+<link rel="stylesheet" href="css/form.css" />
+<link rel="stylesheet" href="css/create.css" />
+<link rel="stylesheet" href="css/edit-list.css" />
+<link rel="stylesheet" href="css/edit-operators.css" />
+</head>
+<body>
+    <div class="dashboard type-maintenance">
+        <div class="dashboard-item dashboard-account">
+            <span class="dashboard-title">Compte</span>
+            <span class="dashboard-value"><a href="" class="home-link" title="Retour à l'accueil">Laforêt</a></span>
+        </div>
+        <div class="dashboard-item">
+            <span class="dashboard-title">Maintenance disponible</span>
+            <span class="dashboard-value">20h / 170</span>
+        </div>
+        <div class="dashboard-item">
+            <span class="dashboard-title">Support disponible</span>
+            <span class="dashboard-value">10h30 / 20</span>
+        </div>
+        <div class="dashboard-item dashboard-contact">
+            <span class="dashboard-title">Hybird</span>
+            <span class="dashboard-value">Jonathan C.</span>
+        </div>
+        <div class="dashboard-item dashboard-button">
+            <div class="dashboard-value">
+                <a href="" title="Quitter l'application">Déconnexion</a>
+            </div>
+        </div>
+    </div>
+   
+    <div class="content-container">
+        <div class="content">
+            <div class="form-content">
+                <div class="form-intro">
+                    <div class="group-title-container">
+                        <div class="group-title">Modifier la liste des intervenants Hybird</div>
+                    </div>
+                </div>
+                <form action="" method="post">
+                    <div class="form-group archive-group form-group-collapsable">
+                        <div class="group-title-container">
+                            <div class="group-title" title="Afficher/cacher la liste des intervenants actifs">Archiver des intervenants</div>
+                        </div>
+
+                        <div class="form-group-collapsable-content">
+                            <span class="list-intro">Sélectionner les intervenants que vous voulez rendre inactifs, parmi les 17 intervenants Hybird actuellement actifs:</span>
+                            <ul class="checkbox-list">
+                                <li>
+                                    <label>
+                                        <input value="1" type="checkbox">
+                                        <div class="item-container">
+                                            <div class="item-name">
+                                                Rémy Rakic
+                                            </div>
+                                            <div class="item-description">Intervenant <span class="typography dash">&mdash;</span> projets: Auchan, Laforêt</div>
+                                        </div>
+                                    </label>
+                                </li>
+                                <li>
+                                    <label>
+                                        <input value="2" type="checkbox" checked>
+                                        <div class="item-container">
+                                            <div class="item-name">Hugo Smett</div>
+                                            <div class="item-description">Intervenant <span class="typography dash">&mdash;</span> projets: Auchan</div>
+                                        </div>
+                                    </label>
+                                </li>
+                                <li>
+                                    <label>
+                                        <input value="3" type="checkbox">
+                                        <div class="item-container">
+                                            <div class="item-name">Jean-Mougli Armand</div>
+                                            <div class="item-description">Intervenant <span class="typography dash">&mdash;</span> projets: Auchan, Laforêt</div>
+                                        </div>
+                                    </label>
+                                </li>
+                                <li>
+                                    <label>
+                                        <input value="4" type="checkbox">
+                                        <div class="item-container">
+                                            <div class="item-name">Qunny B</div>
+                                            <div class="item-description">Intervenant <span class="typography dash">&mdash;</span> projets: La Coque de Nacre, Laforêt</div>
+                                        </div>
+                                    </label>
+                                </li>
+                                <li>
+                                    <label>
+                                        <input value="5" type="checkbox" checked>
+                                        <div class="item-container">
+                                            <div class="item-name">Joe LaFripouille</div>
+                                            <div class="item-description">Intervenant <span class="typography dash">&mdash;</span> Projets: BUT</div>
+                                        </div>
+                                    </label>
+                                </li>                                
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="form-footer">
+                        <button type="submit">Archiver ces intervenants</button>
+                        <span class="cancel">ou <a href="#" onclick="window.history.back()">Ne rien changer</a></span>
+                    </div>
+                </form>
+
+                <form action="" method="post">
+                    <div class="form-group reactivate-form form-group-collapsable form-group-collapsed">
+                        <div class="group-title-container">
+                            <div class="group-title" title="Afficher/cacher la liste des intervenants archivés">Réactiver des intervenants archivés</div>
+                        </div>
+
+                        <div class="form-group-collapsable-content">
+                            <span class="list-intro">Sélectionner les intervenants que vous voulez rendre actifs, parmi les 3 intervenants Hybird actuellement archivés:</span>
+                            <ul class="checkbox-list">
+                                <li>
+                                    <label>
+                                        <input value="1" type="checkbox">
+                                        <div class="item-container">
+                                            <div class="item-name">
+                                                Rémy Rakic
+                                            </div>
+                                            <div class="item-description">Intervenant archivé <span class="typography dash">&mdash;</span> projets: Auchan, Laforêt</div>
+                                        </div>
+                                    </label>
+                                </li>
+                                <li>
+                                    <label>
+                                        <input value="2" type="checkbox" checked>
+                                        <div class="item-container">
+                                            <div class="item-name">Hugo Smett</div>
+                                            <div class="item-description">Intervenant archivé <span class="typography dash">&mdash;</span> projets: Auchan</div>
+                                        </div>
+                                    </label>
+                                </li>
+                                <li>
+                                    <label>
+                                        <input value="3" type="checkbox">
+                                        <div class="item-container">
+                                            <div class="item-name">Jean-Mougli Armand</div>
+                                            <div class="item-description">Intervenant archivé <span class="typography dash">&mdash;</span> projets: Auchan, Laforêt</div>
+                                        </div>
+                                    </label>
+                                </li>
+                                <li>
+                                    <label>
+                                        <input value="4" type="checkbox">
+                                        <div class="item-container">
+                                            <div class="item-name">Qunny B</div>
+                                            <div class="item-description">Intervenant archivé <span class="typography dash">&mdash;</span> projets: La Coque de Nacre, Laforêt</div>
+                                        </div>
+                                    </label>
+                                </li>
+                                <li>
+                                    <label>
+                                        <input value="5" type="checkbox" checked>
+                                        <div class="item-container">
+                                            <div class="item-name">Joe LaFripouille</div>
+                                            <div class="item-description">Intervenant archivé <span class="typography dash">&mdash;</span> projets: BUT</div>
+                                        </div>
+                                    </label>
+                                </li>                                
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="form-footer">
+                        <button type="submit">Activer ces intervenants</button>
+                        <span class="cancel">ou <a href="#" onclick="window.history.back()">Ne rien changer</a></span>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <div class="page-decoration">
+        <div></div>
+        <span title="Cui !">
+            <svg class="icon-hybird" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 20">
+                <path d="M16.36,8.196c0.714,0.068,1.219,0.346,1.762,0.587c1.04-1.811,1.492-4.212,1.678-6.879c0.064-0.122,0.009-0.364,0.028-0.532c0.063-0.158,0.009-0.438,0.027-0.643c0.065-0.076,0.011-0.271,0.028-0.392c0.008-0.158,0.002-0.522-0.056-0.224c-0.548,1.77-1.002,3.812-1.902,5.118c0.326-0.635,0.496-1.425,0.56-2.322c0.064-0.103,0.01-0.325,0.028-0.476c0.046-0.335,0.046-0.866,0-1.202c0-0.252,0.01-0.514-0.056-0.699c0.015,0.108-0.051,0.137-0.029,0.252c-0.391,1.612-0.688,3.319-1.398,4.614c0-0.056,0-0.112,0-0.167c0.065-0.076,0.011-0.271,0.029-0.392c0.064-0.215,0.009-0.551,0.028-0.812c-0.02-0.261,0.036-0.597-0.028-0.811c-0.002-0.438,0.015-0.892-0.057-1.259c0.001,0.065-0.049,0.082-0.027,0.167c-0.794,2.488-1.642,4.923-3.077,6.769c0.61-0.331,1.211-0.674,2.126-0.699C16.137,8.196,16.247,8.196,16.36,8.196z"></path>
+                <path d="M19.156,10.015c-0.903-0.691-1.685-1.364-3.076-1.287c-1.335,0.074-2.107,0.892-2.992,1.454c0.055,0.236,0.403,0.47,0.363,0.615c-2.134-1.083-3.509-2.923-4.222-5.425c0.013-0.089-0.052-0.1-0.029-0.195c-0.064,0.409-0.009,0.94-0.027,1.397C7.909,5.283,7.011,3.627,6.489,1.596C6.456,1.543,6.452,1.464,6.432,1.4C6.367,1.978,6.41,2.69,6.459,3.246c0.083,1.576,0.28,3.039,0.839,4.14C7.032,7.101,6.862,6.722,6.655,6.378C6.587,6.261,6.544,6.117,6.459,6.015C6.126,5.21,5.768,4.433,5.509,3.554C5.42,3.651,5.452,3.87,5.425,4.029c-0.064,0.122-0.01,0.364-0.028,0.531c-0.047,0.168-0.047,0.53,0,0.699C5.416,5.4,5.361,5.613,5.425,5.707c0.124,1.629,0.661,2.845,1.397,3.859c-0.268-0.085-0.468-0.239-0.67-0.392C6.07,9.126,6.022,9.044,5.957,8.979c-0.047-0.047-0.1-0.088-0.14-0.141c-0.012-0.024-0.025-0.05-0.056-0.056c-0.526-0.667-0.945-1.44-1.23-2.349c0.344,2.21,1.049,4.301,2.265,5.733c0.029,0.072,0.111,0.093,0.14,0.167c0.114,0.091,0.217,0.193,0.308,0.308c0.056,0.009,0.054,0.075,0.111,0.084c0.878,0.791,1.914,1.423,3.328,1.679c-0.109,0.142-0.397,0.104-0.587,0.167c-0.168,0-0.336,0-0.504,0c-0.332-0.1-0.825,0.382-1.119,0.644c-0.324,0.288-0.581,0.53-0.838,0.755c-0.576,0.502-1.094,1.095-1.65,1.51c-0.888,0.663-2.005,1.207-2.992,1.791C1.979,19.868,0.982,20.461,0,21.032c0.002,0.054,0.093-0.032,0.168,0c0.233-0.018,0.54,0.037,0.727-0.027c0.149,0,0.298,0,0.448,0c0.26-0.047,0.619,0.004,0.868-0.056c0.148,0,0.297,0,0.447,0c0.093,0,0.186,0,0.279,0c0.624,0.056,1.213,0.147,1.79,0.251c0.027,0,0.055,0,0.084,0c-0.005-0.023,0.011-0.026,0.028-0.027c0.114-0.092,0.216-0.193,0.307-0.308c0.038-0.094,0.164-0.098,0.196-0.196c1.029-0.938,2.201-1.887,3.412-2.769c0.209-0.152,0.359-0.33,0.588-0.363c0.186-0.02,0.447,0.037,0.587-0.028c1.319-0.084,2.47-0.555,3.439-1.146c0.952-0.581,1.934-1.147,2.657-1.902c0.476-0.497,0.823-1.113,1.313-1.594c0.049-0.063,0.116-0.108,0.168-0.168c0.119-0.143,0.25-0.273,0.393-0.392c0.067-0.045,0.123-0.101,0.167-0.168c0.407-0.387,0.98-0.604,1.706-0.672c0.084,0,0.168,0,0.252,0c0.039,0.063,0.195,0.012,0.279,0.028c0.62,0.006,1.057,0.194,1.454,0.419c0-0.019,0-0.037,0-0.056C21.217,11.166,19.899,10.582,19.156,10.015z"></path>
+            </svg>
+        </span>
+        <div></div>
+    </div>
+
+    <div class="footer">
+        <div class="footer-baseline">
+            <strong><a href="http://cremecrm.com">Crème</a></strong> est un logiciel libre, cuisiné en France depuis 2008, par <strong><a href="http://hybird.org">Hybird</a></strong>
+            <span class="footer-baseline-version">— Version 1.7 alpha / Crème glacée</span>
+        </div>
+
+        <div class="footer-columns clearfix">
+            <div class="footer-column footer-column-creme">
+                <div class="column-content">
+                    <span class="footer-column-title">Crème</span>
+                    <ul>
+                        <li><a href="">Documentation</a></li>
+                        <li><a href="">Support Reamaze</a></li>
+                        <li><a href="">Forum</a></li>
+                        <li class="creme-site">— <a href="http://cremecrm.com">cremecrm.com</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-column footer-column-client">
+                <div class="column-content">
+                    <span class="footer-column-title">Votre contact</span>
+                    <ul>
+                        <li>Jonathan Caruana</li>
+                        <li class="hybird-phone">
+                            <svg class="icon icon-telephone" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z"></path></svg>
+                            06 12 34 56 78
+                        </li>
+                        <li class="hybird-contact">
+                            <svg class="icon icon-email" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"></path></svg>
+                            <a href="mailto:jcaruana@hybird.org?subject=Contact Hybird Maintenance&amp;body=%0d%0aEnvoyé depuis url.com">jcaruana@hybird.org</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-column footer-column-hybird">
+                <div class="column-content">
+                    <span class="footer-column-title">
+                        Hybird
+                        <span title="Cui !">
+                            <svg class="icon-hybird" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 20">
+                                <path d="M16.36,8.196c0.714,0.068,1.219,0.346,1.762,0.587c1.04-1.811,1.492-4.212,1.678-6.879c0.064-0.122,0.009-0.364,0.028-0.532c0.063-0.158,0.009-0.438,0.027-0.643c0.065-0.076,0.011-0.271,0.028-0.392c0.008-0.158,0.002-0.522-0.056-0.224c-0.548,1.77-1.002,3.812-1.902,5.118c0.326-0.635,0.496-1.425,0.56-2.322c0.064-0.103,0.01-0.325,0.028-0.476c0.046-0.335,0.046-0.866,0-1.202c0-0.252,0.01-0.514-0.056-0.699c0.015,0.108-0.051,0.137-0.029,0.252c-0.391,1.612-0.688,3.319-1.398,4.614c0-0.056,0-0.112,0-0.167c0.065-0.076,0.011-0.271,0.029-0.392c0.064-0.215,0.009-0.551,0.028-0.812c-0.02-0.261,0.036-0.597-0.028-0.811c-0.002-0.438,0.015-0.892-0.057-1.259c0.001,0.065-0.049,0.082-0.027,0.167c-0.794,2.488-1.642,4.923-3.077,6.769c0.61-0.331,1.211-0.674,2.126-0.699C16.137,8.196,16.247,8.196,16.36,8.196z"></path>
+                                <path d="M19.156,10.015c-0.903-0.691-1.685-1.364-3.076-1.287c-1.335,0.074-2.107,0.892-2.992,1.454c0.055,0.236,0.403,0.47,0.363,0.615c-2.134-1.083-3.509-2.923-4.222-5.425c0.013-0.089-0.052-0.1-0.029-0.195c-0.064,0.409-0.009,0.94-0.027,1.397C7.909,5.283,7.011,3.627,6.489,1.596C6.456,1.543,6.452,1.464,6.432,1.4C6.367,1.978,6.41,2.69,6.459,3.246c0.083,1.576,0.28,3.039,0.839,4.14C7.032,7.101,6.862,6.722,6.655,6.378C6.587,6.261,6.544,6.117,6.459,6.015C6.126,5.21,5.768,4.433,5.509,3.554C5.42,3.651,5.452,3.87,5.425,4.029c-0.064,0.122-0.01,0.364-0.028,0.531c-0.047,0.168-0.047,0.53,0,0.699C5.416,5.4,5.361,5.613,5.425,5.707c0.124,1.629,0.661,2.845,1.397,3.859c-0.268-0.085-0.468-0.239-0.67-0.392C6.07,9.126,6.022,9.044,5.957,8.979c-0.047-0.047-0.1-0.088-0.14-0.141c-0.012-0.024-0.025-0.05-0.056-0.056c-0.526-0.667-0.945-1.44-1.23-2.349c0.344,2.21,1.049,4.301,2.265,5.733c0.029,0.072,0.111,0.093,0.14,0.167c0.114,0.091,0.217,0.193,0.308,0.308c0.056,0.009,0.054,0.075,0.111,0.084c0.878,0.791,1.914,1.423,3.328,1.679c-0.109,0.142-0.397,0.104-0.587,0.167c-0.168,0-0.336,0-0.504,0c-0.332-0.1-0.825,0.382-1.119,0.644c-0.324,0.288-0.581,0.53-0.838,0.755c-0.576,0.502-1.094,1.095-1.65,1.51c-0.888,0.663-2.005,1.207-2.992,1.791C1.979,19.868,0.982,20.461,0,21.032c0.002,0.054,0.093-0.032,0.168,0c0.233-0.018,0.54,0.037,0.727-0.027c0.149,0,0.298,0,0.448,0c0.26-0.047,0.619,0.004,0.868-0.056c0.148,0,0.297,0,0.447,0c0.093,0,0.186,0,0.279,0c0.624,0.056,1.213,0.147,1.79,0.251c0.027,0,0.055,0,0.084,0c-0.005-0.023,0.011-0.026,0.028-0.027c0.114-0.092,0.216-0.193,0.307-0.308c0.038-0.094,0.164-0.098,0.196-0.196c1.029-0.938,2.201-1.887,3.412-2.769c0.209-0.152,0.359-0.33,0.588-0.363c0.186-0.02,0.447,0.037,0.587-0.028c1.319-0.084,2.47-0.555,3.439-1.146c0.952-0.581,1.934-1.147,2.657-1.902c0.476-0.497,0.823-1.113,1.313-1.594c0.049-0.063,0.116-0.108,0.168-0.168c0.119-0.143,0.25-0.273,0.393-0.392c0.067-0.045,0.123-0.101,0.167-0.168c0.407-0.387,0.98-0.604,1.706-0.672c0.084,0,0.168,0,0.252,0c0.039,0.063,0.195,0.012,0.279,0.028c0.62,0.006,1.057,0.194,1.454,0.419c0-0.019,0-0.037,0-0.056C21.217,11.166,19.899,10.582,19.156,10.015z"></path>
+                            </svg>
+                        </span>
+                    </span>
+                    <ul>
+                        <li class="hybird-site">— <a href="http://hybird.org">hybird.org</a></li>
+                        <li class="hybird-phone">
+                            <svg class="icon icon-telephone" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z"></path></svg>
+                            04 91 11 87 78
+                        </li>
+                        <li class="hybird-contact">
+                            <svg class="icon icon-email" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"></path></svg>
+                            <a href="mailto:contact@hybird.org?subject=Contact Hybird Maintenance&amp;body=%0d%0aEnvoyé depuis url.com">contact@hybird.org</a>
+                        </li>
+                        <li class="hybird-address">
+                            Hôtel Technologique <br>
+                            45 rue Frédéric Joliot Curie <br>
+                            13013 MARSEILLE
+                        </li>
+
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script>
+        var collapsableTriggers = document.querySelectorAll("form .group-title");
+        for (var i = 0; i < collapsableTriggers.length; ++i) {
+            var trigger = collapsableTriggers[i];
+            trigger.addEventListener("click", function(e) {
+                var className = "form-group-collapsed";
+                
+                var collapsable = this.parentElement.parentElement;                
+                if (collapsable.className.indexOf(className) === -1) {
+                    collapsable.className += " " + className;
+                } else {
+                    collapsable.className = collapsable.className.replace(className, "");
+                }
+            }, false);
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Add a page to archive currently active operators, and activate currently archived operators.

This page should be shown with the link at the top of the dashboard.

The page has two collapsable forms:
- the first and most important one, expanded by default, allows selecting one or more of the currently active operators, in order to archive them.
- the second one, with a low probability of being used except in case of errors using the 1st form, is collapsed by default, and allows selecting one or more of the currently archived/inactive operators, in order to reactivate them.

Default state:
![image](https://user-images.githubusercontent.com/247183/38040652-44c71328-32b0-11e8-8209-b79ef9c8d828.png)

Both forms closed
![image](https://user-images.githubusercontent.com/247183/38040756-7be019ea-32b0-11e8-94ec-fa12c024b866.png)

Second form opened
![image](https://user-images.githubusercontent.com/247183/38040744-74749fb4-32b0-11e8-9ad9-6551529c60d0.png)


Both forms opened
![image](https://user-images.githubusercontent.com/247183/38040708-5d3d019c-32b0-11e8-9283-54a51163f985.png)
