### PR TITLE
Python dependencies upgrades

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 coverage==4.5.1
 django-debug-toolbar==1.9.1
-django-extensions==2.0.0
+django-extensions==2.0.6
 django-grappelli==2.11.1
 django-ordered-model==1.4.3
 django>=2.0,<2.0.1024
@@ -11,7 +11,7 @@ ipython==6.2.1
 isort==4.3.4
 psycopg2==2.7.4
 python-crontab==2.2.8
-python-dateutil==2.6.1
+python-dateutil==2.7.2
 pytz==2018.3
-raven==6.5.0
+raven==6.6.0
 tox==2.9.1


### PR DESCRIPTION
django-extensions (2.0.0) - Latest: 2.0.6 [wheel]
python-dateutil (2.6.1) - Latest: 2.7.2 [wheel]
raven (6.5.0) - Latest: 6.6.0 [wheel]