### PR TITLE
Fixes 55, normalize views' names

### DIFF
--- a/hymaintenance/high_ui/tests/views/test_consumer_views.py
+++ b/hymaintenance/high_ui/tests/views/test_consumer_views.py
@@ -6,7 +6,7 @@ from customers.tests.factories import CompanyFactory, MaintenanceUserFactory
 from maintenance.models import MaintenanceConsumer
 
 
-class CreateConsumerViewTestCase(TestCase):
+class ConsumerCreateViewTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):

--- a/hymaintenance/high_ui/urls.py
+++ b/hymaintenance/high_ui/urls.py
@@ -3,8 +3,8 @@
 from django.urls import path
 
 from .views import (
-    CompanyDetailView, CreateConsumerView, CreateManagerUserView, CreateOperatorUserView, CreateProjectView, HomeView, IssueCreateView,
-    IssueDetailView, UpdateIssueView, UpdateProjectView
+    CompanyDetailView, ConsumerCreateView, HomeView, IssueCreateView, IssueDetailView, IssueUpdateView, ManagerUserCreateView, OperatorUserCreateView,
+    ProjectCreateView, ProjectUpdateView
 )
 
 
@@ -15,10 +15,10 @@ urlpatterns = [
     path(r'company/<int:pk>/', CompanyDetailView.as_view(),
          name='company-details'),
 
-    path(r'project/add/', CreateProjectView.as_view(),
+    path(r'project/add/', ProjectCreateView.as_view(),
          name='add_project'),
 
-    path(r'project/<slug:company_name>/change/', UpdateProjectView.as_view(),
+    path(r'project/<slug:company_name>/change/', ProjectUpdateView.as_view(),
          name='change_project'),
 
     path(r'issue/<slug:company_name>/add/', IssueCreateView.as_view(),
@@ -27,16 +27,16 @@ urlpatterns = [
     path(r'issue/<slug:company_name>/<int:company_issue_number>/', IssueDetailView.as_view(),
          name='issue-details'),
 
-    path(r'issue/<slug:company_name>/<int:company_issue_number>/change/', UpdateIssueView.as_view(),
+    path(r'issue/<slug:company_name>/<int:company_issue_number>/change/', IssueUpdateView.as_view(),
          name='change_issue'),
 
-    path(r'consumer/add/<slug:company_name>/', CreateConsumerView.as_view(),
+    path(r'consumer/add/<slug:company_name>/', ConsumerCreateView.as_view(),
          name='company-add_consumer'),
 
-    path(r'manager/add/<slug:company_name>/', CreateManagerUserView.as_view(),
+    path(r'manager/add/<slug:company_name>/', ManagerUserCreateView.as_view(),
          name='company-add_manager'),
 
-    path(r'maintainer/add/<slug:company_name>/', CreateOperatorUserView.as_view(),
+    path(r'maintainer/add/<slug:company_name>/', OperatorUserCreateView.as_view(),
          name='company-add_operator'),
 
 ]

--- a/hymaintenance/high_ui/views.py
+++ b/hymaintenance/high_ui/views.py
@@ -183,7 +183,7 @@ class IssueCreateView(LoginRequiredMixin, CreateViewWithCompany):
         return self.company.get_absolute_url()
 
 
-class UpdateIssueView(LoginRequiredMixin, ViewWithCompany, UpdateView):
+class IssueUpdateView(LoginRequiredMixin, ViewWithCompany, UpdateView):
     form_class = MaintenanceIssueUpdateForm
     template_name = "high_ui/forms/update_issue.html"
     model = MaintenanceIssue
@@ -195,7 +195,7 @@ class UpdateIssueView(LoginRequiredMixin, ViewWithCompany, UpdateView):
         return MaintenanceIssue.objects.filter(company=self.company)
 
     def get_context_data(self, **kwargs):
-        context = super(UpdateIssueView, self).get_context_data(**kwargs)
+        context = super().get_context_data(**kwargs)
         context['channels'] = IncomingChannel.objects.all()
 
         contracts = MaintenanceContract.objects.filter(company=self.object.company_id, disabled=False)
@@ -207,12 +207,12 @@ class UpdateIssueView(LoginRequiredMixin, ViewWithCompany, UpdateView):
                                                         'company_issue_number': self.object.company_issue_number})
 
 
-class CreateConsumerView(LoginRequiredMixin, CreateViewWithCompany):
+class ConsumerCreateView(LoginRequiredMixin, CreateViewWithCompany):
     form_class = MaintenanceConsumerCreateForm
     template_name = "high_ui/forms/add_consumer.html"
 
 
-class CreateManagerUserView(LoginRequiredMixin, CreateViewWithCompany):
+class ManagerUserCreateView(LoginRequiredMixin, CreateViewWithCompany):
     form_class = ManagerUserCreateForm
     template_name = "high_ui/forms/add_user.html"
 
@@ -223,7 +223,7 @@ class CreateManagerUserView(LoginRequiredMixin, CreateViewWithCompany):
         return context
 
 
-class CreateOperatorUserView(LoginRequiredMixin, CreateViewWithCompany):
+class OperatorUserCreateView(LoginRequiredMixin, CreateViewWithCompany):
     form_class = OperatorUserCreateForm
     template_name = "high_ui/forms/add_user.html"
 
@@ -241,7 +241,7 @@ class CreateOperatorUserView(LoginRequiredMixin, CreateViewWithCompany):
         return context
 
 
-class CreateProjectView(FormView):
+class ProjectCreateView(FormView):
     form_class = ProjectCreateForm
     template_name = "high_ui/forms/add_project.html"
     success_url = "/"
@@ -258,7 +258,7 @@ class CreateProjectView(FormView):
         return super().form_valid(form)
 
 
-class UpdateProjectView(LoginRequiredMixin, ViewWithCompany, FormView):
+class ProjectUpdateView(LoginRequiredMixin, ViewWithCompany, FormView):
     form_class = ProjectUpdateForm
     template_name = "high_ui/forms/update_project.html"
     success_url = "/"


### PR DESCRIPTION
Fixes #55 

Finalement j'ai normalisé dans l'autre sens car je trouvais plus correct au niveau de l'anglais.
`<nomModel><descriptifVue>View`
exemple : `IssueUpdateView` ou `CompanyDetailView`