### PR TITLE
Refs 178, correctif bug proposition de salariés

### DIFF
--- a/hymaintenance/maintenance/forms/issue.py
+++ b/hymaintenance/maintenance/forms/issue.py
@@ -39,7 +39,7 @@ class MaintenanceIssueCreateForm(forms.ModelForm):
         self.company = kwargs.pop("company")
         super(MaintenanceIssueCreateForm, self).__init__(*args, **kwargs)
 
-        self.fields["consumer_who_ask"].queryset = self.company.maintenanceconsumer_set
+        self.fields["consumer_who_ask"].queryset = self.company.maintenanceconsumer_set.get_used_consumers()
         self.fields["user_who_fix"].choices = self.company.get_operators_choices()
         self.fields["context_description_file"].required = False
         self.fields["resolution_description_file"].required = False


### PR DESCRIPTION
Fixes #178 

corrige le bug de proposition de salariés lors de la création d'une issue. Maintenant le formulaire ne propose que les salariés actifs.