### PR TITLE
Refs 203, quick fix

### DIFF
--- a/hymaintenance/customers/locale/fr/LC_MESSAGES/django.po
+++ b/hymaintenance/customers/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-07-04 15:45+0200\n"
+"POT-Creation-Date: 2018-07-05 13:29+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,23 +18,23 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: admin.py:23
+#: customers/admin.py:23
 msgid "The two password fields didn't match."
 msgstr ""
 
-#: admin.py:24 admin.py:56
+#: customers/admin.py:24 customers/admin.py:56
 msgid "Password"
 msgstr "Mot de passe"
 
-#: admin.py:26
+#: customers/admin.py:26
 msgid "Password confirmation"
 msgstr "Confirmation mot de passe"
 
-#: admin.py:28
+#: customers/admin.py:28
 msgid "Enter the same password as above, for verification."
 msgstr "Entrez le même mot de passe que précédement, pour vérification"
 
-#: admin.py:58
+#: customers/admin.py:58
 msgid ""
 "Raw passwords are not stored, so there is no way to see this user's "
 "password, but you can change the password using <a href=\"password/\">this "
@@ -43,72 +43,69 @@ msgstr ""
 "Les mots de passe ne sont pas stockés en clair. Vous pouvez les modifier en "
 "utilisant <a href=\"password/\">ce formulaire</a>. "
 
-#: admin.py:89
+#: customers/admin.py:89
 msgid "Permissions"
 msgstr "Permissions"
 
-#: admin.py:95
+#: customers/admin.py:95
 msgid "Personal info"
 msgstr "Informations personnelles"
 
-#: forms.py:152
+#: customers/forms.py:152 customers/tests/forms/test_user_forms.py:178
 msgid "Invalid password."
 msgstr "Mot de passe invalide."
 
-#: models/user.py:29
+#: customers/models/user.py:29
 msgid "The given email must be set"
 msgstr ""
 
-#: models/user.py:59
+#: customers/models/user.py:59
 msgid "Creation date"
 msgstr "Date de création"
 
-#: models/user.py:60
+#: customers/models/user.py:60
 msgid "Last modification date"
 msgstr "Date de dernière modification"
 
-#: models/user.py:62
+#: customers/models/user.py:62
 msgid "first name"
 msgstr "Prénom"
 
-#: models/user.py:63
+#: customers/models/user.py:63
 msgid "last name"
 msgstr "Nom de famille"
 
-#: models/user.py:65
+#: customers/models/user.py:65
 msgid "email address"
 msgstr "Adresse e-mail"
 
-#: models/user.py:68
+#: customers/models/user.py:68
 msgid "A user with that username already exists."
 msgstr "Un utilisateur avec ce login existe déjà"
 
-#: models/user.py:72
+#: customers/models/user.py:72
 msgid "staff status"
 msgstr "Status Staff"
 
-#: models/user.py:72
+#: customers/models/user.py:72
 msgid "Designates whether the user can log into this admin site."
 msgstr ""
 
-#: models/user.py:75
+#: customers/models/user.py:75
 msgid "active"
 msgstr "Actif"
 
-#: models/user.py:78
+#: customers/models/user.py:78
 msgid ""
 "Designates whether this user should be treated as active. Unselect this "
 "instead of deleting accounts."
 msgstr ""
 
-#: models/user.py:85
+#: customers/models/user.py:85
 msgid "Managed Companies"
 msgstr ""
 
-#: tests/forms/test_user_forms.py:29 tests/forms/test_user_forms.py:159
+#: customers/tests/forms/test_user_forms.py:29
+#: customers/tests/forms/test_user_forms.py:159
 msgid "This field is required."
-msgstr ""
-
-#: tests/forms/test_user_forms.py:178
-msgid "Invalid password"
 msgstr ""

--- a/hymaintenance/high_ui/locale/fr/LC_MESSAGES/django.po
+++ b/hymaintenance/high_ui/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-07-04 15:44+0200\n"
+"POT-Creation-Date: 2018-07-05 13:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -69,17 +69,16 @@ msgstr "Mot de passe"
 #: templatetags/print_fields.py:55 tests/templatetags/test_print_field.py:75
 #: tests/templatetags/test_print_field.py:80
 msgid "project:"
-msgstr "projet&nbsp;:"
+msgstr "projet :"
 
 #: templatetags/print_fields.py:55 tests/templatetags/test_print_field.py:75
 msgid "none"
 msgstr "aucun"
 
 #: tests/templatetags/test_print_field.py:90
-#, fuzzy
-#| msgid "project:"
+#: tests/templatetags/test_print_field.py:94
 msgid "projects:"
-msgstr "projet&nbsp;:"
+msgstr "projets :"
 
 #~ msgid "Create issue"
 #~ msgstr "Nouvelle demande"

--- a/hymaintenance/high_ui/templatetags/print_fields.py
+++ b/hymaintenance/high_ui/templatetags/print_fields.py
@@ -2,7 +2,6 @@
 from django.template import Library
 from django.utils.html import mark_safe
 from django.utils.translation import ugettext as _
-from django.utils.translation import ungettext as _p
 
 from customers.models.user import MaintenanceUser
 from customers.models.user import get_companies_of_operator
@@ -51,5 +50,8 @@ def print_operator_projects(operator_id):
     projects = get_companies_of_operator(operator)
     if projects:
         projects_names = [project.name for project in projects]
-        return _p("project:", "projects:", len(projects_names)) + ", ".join(projects_names)
-    return _("project:") + _("none")
+        if len(projects_names) == 1:
+            return _("project:") + " " + projects_names[0]
+        else:
+            return _("projects:") + " " + ", ".join(projects_names)
+    return _("project:") + " " + _("none")

--- a/hymaintenance/high_ui/tests/templatetags/test_print_field.py
+++ b/hymaintenance/high_ui/tests/templatetags/test_print_field.py
@@ -72,12 +72,12 @@ class PrintOperatorProjectsTestCase(TestCase):
         self.user = OperatorUserFactory(id=self.op_id)
 
     def test_print_when_operator_has_no_project(self):
-        self.assertEqual(_("project:") + _("none"), print_operator_projects(self.op_id))
+        self.assertEqual(_("project:") + " " + _("none"), print_operator_projects(self.op_id))
 
     def test_print_when_operator_has_one_project(self):
         company = CompanyFactory()
         self.user.operator_for.add(company)
-        self.assertEqual(_("project:") + "{}".format(company.name), print_operator_projects(self.op_id))
+        self.assertEqual(_("project:") + " " + "{}".format(company.name), print_operator_projects(self.op_id))
 
     def test_print_when_operator_has_projects(self):
         company1 = CompanyFactory()
@@ -87,6 +87,6 @@ class PrintOperatorProjectsTestCase(TestCase):
         company3 = CompanyFactory()
         self.user.operator_for.add(company3)
         self.assertEqual(
-            _("projects:") + "{}, {}, {}".format(company1.name, company2.name, company3.name),
+            _("projects:") + " " + "{}, {}, {}".format(company1.name, company2.name, company3.name),
             print_operator_projects(self.op_id),
         )

--- a/hymaintenance/maintenance/locale/fr/LC_MESSAGES/django.po
+++ b/hymaintenance/maintenance/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-27 11:50+0200\n"
+"POT-Creation-Date: 2018-07-05 13:29+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,53 +18,62 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: maintenance/forms.py:114 maintenance/tests/forms/test_project_forms.py:118
+#: maintenance/forms/project.py:54 maintenance/forms/project.py:153
+#: maintenance/tests/forms/test_project_forms.py:214
+#: maintenance/tests/forms/test_project_forms.py:391
 msgid "This company already exists"
 msgstr "Cette société existe déjà"
 
-#: maintenance/migrations/0010_auto_20180315_0012.py:15
 #: maintenance/migrations/0010_auto_20180315_0012.py:17
-msgid "Support"
-msgstr "Support"
-
-#: maintenance/migrations/0010_auto_20180315_0012.py:18
-#: maintenance/migrations/0010_auto_20180315_0012.py:20
+#: maintenance/migrations/0010_auto_20180315_0012.py:19
 msgid "Maintenance"
 msgstr "Maintenance"
 
-#: maintenance/migrations/0010_auto_20180315_0012.py:21
 #: maintenance/migrations/0010_auto_20180315_0012.py:23
+msgid "Support"
+msgstr "Support"
+
+#: maintenance/migrations/0010_auto_20180315_0012.py:28
+#: maintenance/migrations/0010_auto_20180315_0012.py:30
 msgid "Corrective"
 msgstr "Corrective"
 
-#: maintenance/models/consumer.py:9
+#: maintenance/models/consumer.py:15
 msgid "Consumer's Name"
 msgstr "Nom de l'utilisateur de maintenance"
 
-#: maintenance/models/contract.py:18
+#: maintenance/models/contract.py:24
 msgid "Available total time"
 msgstr "Total du temps disponible"
 
-#: maintenance/models/contract.py:18
+#: maintenance/models/contract.py:25
 msgid "Consummed total time"
 msgstr "Total du temps consommé"
 
-#: maintenance/models/contract.py:20
+#: maintenance/models/contract.py:28
 #, fuzzy
 #| msgid "Name of Model"
 msgid "Name of counter"
 msgstr "Nom du Modéle"
 
-#: maintenance/models/contract.py:21 maintenance/models/credit.py:10
-#: maintenance/models/issue.py:11
+#: maintenance/models/contract.py:29 maintenance/models/credit.py:10
+#: maintenance/models/issue.py:40
 msgid "Company"
 msgstr "Société"
 
-#: maintenance/models/contract.py:23 maintenance/models/other_models.py:9
+#: maintenance/models/contract.py:31 maintenance/models/other_models.py:9
 msgid "Visible to customer user"
 msgstr "Visible pour les managers"
 
-#: maintenance/models/contract.py:26
+#: maintenance/models/contract.py:32
+msgid "Disable the contract"
+msgstr ""
+
+#: maintenance/models/contract.py:33
+msgid "Start Date"
+msgstr ""
+
+#: maintenance/models/contract.py:35
 msgid "Counter type"
 msgstr "Type de compteur"
 
@@ -72,25 +81,23 @@ msgstr "Type de compteur"
 msgid "Date of Action"
 msgstr "Date de l'action"
 
-#: maintenance/models/issue.py:20
+#: maintenance/models/issue.py:39
+#, fuzzy
+#| msgid "Issue Date"
+msgid "Issue number"
+msgstr "Date du problème"
+
+#: maintenance/models/issue.py:62
 msgid "Subject"
 msgstr "Sujet"
 
-#: maintenance/models/issue.py:21
+#: maintenance/models/issue.py:63
 msgid "Issue Date"
 msgstr "Date du problème"
 
-#: maintenance/models/other_models.py:6
+#: maintenance/models/other_models.py:8
 msgid "Name of Type"
 msgstr "Nom du Type"
-
-#: maintenance/models/other_models.py:7
-msgid "CSS class for HTML"
-msgstr "Class CSS pour le HTML"
-
-#: maintenance/models/other_models.py:8
-msgid "Label for HTML"
-msgstr "Label pour le HTML"
 
 #: maintenance/models/other_models.py:12
 msgid "Maintenance's Type"
@@ -100,10 +107,44 @@ msgstr "Type de la maintenance"
 msgid "Maintenance's Types"
 msgstr "Types des maintenances"
 
-#: maintenance/models/other_models.py:20
+#: maintenance/models/other_models.py:23
 msgid "Name of Incoming Channel"
 msgstr "Canal d'entrée des demandes"
 
-#: maintenance/models/other_models.py:23 maintenance/models/other_models.py:24
+#: maintenance/models/other_models.py:26 maintenance/models/other_models.py:27
 msgid "Maintenance's Incoming Channel"
 msgstr "Canal d'entrée des demandes"
+
+#: maintenance/tests/forms/test_issue_forms.py:78
+#: maintenance/tests/forms/test_issue_forms.py:293
+#: maintenance/tests/forms/test_project_forms.py:65
+#: maintenance/tests/forms/test_project_forms.py:266
+msgid "This field is required."
+msgstr ""
+
+#: maintenance/tests/forms/test_issue_forms.py:102
+#: maintenance/tests/forms/test_issue_forms.py:315
+#, python-format
+msgid "Invalid duration type: '%s'"
+msgstr ""
+
+#: maintenance/tests/forms/test_issue_forms.py:116
+#: maintenance/tests/forms/test_issue_forms.py:328
+#: maintenance/tests/forms/test_project_forms.py:223
+#: maintenance/tests/forms/test_project_forms.py:400
+#, python-format
+msgid "Ensure this value is greater than or equal to %(limit_value)s."
+msgstr ""
+
+#: maintenance/tests/forms/test_issue_forms.py:129
+#: maintenance/tests/forms/test_issue_forms.py:341
+#: maintenance/tests/forms/test_project_forms.py:233
+#: maintenance/tests/forms/test_project_forms.py:410
+msgid "Enter a whole number."
+msgstr ""
+
+#~ msgid "CSS class for HTML"
+#~ msgstr "Class CSS pour le HTML"
+
+#~ msgid "Label for HTML"
+#~ msgstr "Label pour le HTML"


### PR DESCRIPTION
* remove ungettext because it's not working. It do not translate the string when singular either plurial.
* remove non-breakable space in .po because it's not well print on the template and the span never wraps.