### PR TITLE
Refs 275, fixes user_who_fix initial value of create issue form

### DIFF
--- a/hymaintenance/maintenance/forms/issue.py
+++ b/hymaintenance/maintenance/forms/issue.py
@@ -41,7 +41,7 @@ class MaintenanceIssueCreateForm(forms.ModelForm):
         super(MaintenanceIssueCreateForm, self).__init__(*args, **kwargs)
 
         self.fields["consumer_who_ask"].queryset = self.company.maintenanceconsumer_set.all()
-        self.fields["user_who_fix"].choices = self.company.get_operators_choices()
+        self.fields["user_who_fix"].choices = self.company.get_active_operators_choices()
         self.fields["context_description_file"].required = False
         self.fields["resolution_description_file"].required = False
 

--- a/hymaintenance/maintenance/forms/project.py
+++ b/hymaintenance/maintenance/forms/project.py
@@ -93,7 +93,7 @@ class ProjectCreateForm(ProjectForm):
         if operator:
             operator.operator_for.add(company)
         else:
-            for operator in MaintenanceUser.objects.get_operator_users_queryset():
+            for operator in MaintenanceUser.objects.get_active_operator_users_queryset():
                 operator.operator_for.add(company)
         maintenance_types = MaintenanceType.objects.order_by("id")
 

--- a/hymaintenance/maintenance/tests/forms/test_issue_forms.py
+++ b/hymaintenance/maintenance/tests/forms/test_issue_forms.py
@@ -81,6 +81,16 @@ class IssueCreateFormTestCase(TestCase):
             },
         )
 
+    def test_create_form_user_who_fixes_initial_values(self):
+        operator = OperatorUserFactory(first_name="Chell", is_active=True)
+        operator2 = OperatorUserFactory(first_name="NotChell", is_active=False)
+        operator.operator_for.add(self.company)
+        operator2.operator_for.add(self.company)
+        form = MaintenanceIssueCreateForm(company=self.company, data={})
+        ids = (ids for ids, name in form.fields["user_who_fix"].choices)
+        self.assertIn(operator.id, ids)
+        self.assertNotIn(operator2.id, ids)
+
     def test_when_i_bound_a_create_form_with_invalid_duration_type_i_have_an_error(self):
         with SetDjangoLanguage("en"):
             subject = "subject of the issue"

--- a/hymaintenance/maintenance/tests/forms/test_project_forms.py
+++ b/hymaintenance/maintenance/tests/forms/test_project_forms.py
@@ -251,6 +251,23 @@ class ProjectCreateFormTestCase(TestCase):
         self.assertEqual(1, companies.count())
         self.assertEqual(operator, companies.first().contact)
 
+    def test_create_project_when_there_are_archived_operators(self):
+        operator = OperatorUserFactory(first_name="Chell", is_active=True)
+        operator2 = OperatorUserFactory(first_name="NotChell", is_active=False)
+        dict_for_post = self.__get_dict_for_post()
+        dict_for_post["contract1_visible"] = 1
+
+        form = ProjectCreateForm(data=dict_for_post)
+        is_valid = form.is_valid()
+        form.create_company_and_contracts()
+
+        self.assertTrue(is_valid)
+        companies = Company.objects.all()
+        self.assertEqual(1, companies.count())
+        operators = companies.first().managed_by.all()
+        self.assertIn(operator, operators)
+        self.assertNotIn(operator2, operators)
+
 
 class ProjectUpdateFormTestCase(TestCase):
     @classmethod


### PR DESCRIPTION
Fixes #275 
* n'ajoute plus les intervenants inactifs au nouveau projet lors de sa création,
* ne propose plus les intervenants inactifs dans la liste de choix d'intervenants dans le formulaire de création de demande.