### PR TITLE
Jmad fix bug extra context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
       - run: pip install tox
       - run: pip install coveralls
       - run: tox -e "flake8"
+      - run: tox -e "migrate"
       - run: tox -e "py36-django2.0"
       - run: coveralls
 #

--- a/Makefile
+++ b/Makefile
@@ -38,5 +38,8 @@ test: run-tests-and-coverage
 
 ci-test: run-lint run-sqlite-only-tests
 
+migrate:
+	python hymaintenance/manage.py migrate --settings=hymaintenance.tests_settings
+
 .PHONY: all install all_included run-lint ci-test run-only-tests run-sqlite-only-tests auto-pep8 auto-isort test run-sqlite-tests-and-coverage run-tests-and-coverage
 

--- a/hymaintenance/high_ui/context_processors.py
+++ b/hymaintenance/high_ui/context_processors.py
@@ -1,0 +1,5 @@
+from .views.base import get_context_data_footer
+
+
+def context_data_footer(request):
+    return get_context_data_footer()

--- a/hymaintenance/high_ui/tests/views/test_login_view.py
+++ b/hymaintenance/high_ui/tests/views/test_login_view.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from maintenance.tests.factories import create_project
+
+from ...models import GeneralInformation
+
+
+class LoginViewTestCase(TestCase):
+    def test_general_info_is_displayed(self):
+        self.company, _, _, _ = create_project()
+        self.login_url = reverse("login")
+
+        self.company.contact = None
+        self.company.save()
+        general_info = GeneralInformation.objects.all().first()
+
+        response = self.client.get(self.login_url)
+
+        self.assertContains(response, general_info.name)
+        self.assertContains(response, general_info.email)
+        self.assertContains(response, general_info.phone)

--- a/hymaintenance/hymaintenance/settings.py
+++ b/hymaintenance/hymaintenance/settings.py
@@ -76,6 +76,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "high_ui.context_processors.context_data_footer",
             ]
         },
     }

--- a/hymaintenance/hymaintenance/urls.py
+++ b/hymaintenance/hymaintenance/urls.py
@@ -22,44 +22,30 @@ from django.urls import path
 from django.urls import reverse_lazy
 from django.views.generic import RedirectView
 
-from high_ui.views.base import get_context_data_footer
-
 
 urlpatterns = [
     path("hymaintadmin/", admin.site.urls),
     path("high_ui/", include("high_ui.urls", namespace="high_ui")),
-    path(
-        "login",
-        auth_views.LoginView.as_view(template_name="auth/login.html", extra_context=get_context_data_footer()),
-        name="login",
-    ),
+    path("login", auth_views.LoginView.as_view(template_name="auth/login.html"), name="login"),
     path("logout", auth_views.logout_then_login, name="logout"),
     path(
         "password_reset",
-        auth_views.PasswordResetView.as_view(
-            template_name="auth/password_reset_form.html", extra_context=get_context_data_footer()
-        ),
+        auth_views.PasswordResetView.as_view(template_name="auth/password_reset_form.html"),
         name="password_reset",
     ),
     path(
         "password_reset/done/",
-        auth_views.PasswordResetDoneView.as_view(
-            template_name="auth/password_reset_done.html", extra_context=get_context_data_footer()
-        ),
+        auth_views.PasswordResetDoneView.as_view(template_name="auth/password_reset_done.html"),
         name="password_reset_done",
     ),
     path(
         "reset/<uidb64>/<token>/",
-        auth_views.PasswordResetConfirmView.as_view(
-            template_name="auth/password_reset_confirm.html", extra_context=get_context_data_footer()
-        ),
+        auth_views.PasswordResetConfirmView.as_view(template_name="auth/password_reset_confirm.html"),
         name="password_reset_confirm",
     ),
     path(
         "reset/done/",
-        auth_views.PasswordResetCompleteView.as_view(
-            template_name="auth/password_reset_complet.html", extra_context=get_context_data_footer()
-        ),
+        auth_views.PasswordResetCompleteView.as_view(template_name="auth/password_reset_complet.html"),
         name="password_reset_complete",
     ),
     path("", RedirectView.as_view(url=reverse_lazy("high_ui:dashboard"), permanent=False)),

--- a/tox.ini
+++ b/tox.ini
@@ -35,5 +35,8 @@ commands = make run-sqlite-tests-and-coverage
 [testenv:flake8]
 commands = make run-lint
 
+[testenv:migrate]
+commands = make migrate
+
 [testenv:py36-django2.0]
 commands = make run-tests-and-coverage


### PR DESCRIPTION
Corrige un bug du fait de l'appel de get_context_data_footer() en temps que génération d'extra context des url du url.py. 

get_context_data_footer() a besoin de la base de données pour fonctionner. Sauf qu'au moment où les fichiers url.py sont lus (et donc que get_context_data_footer() qui génére le extra_context est appelée), lorsqu'on lance les migrations, il est possible que la base de données n'existe pas encore (si par exemple c'est la première fois qu'on lance le migrate. Et donc ça ne marche pas vu que les tables en base n'existent pas encore.

Là j'ai décidé d'utiliser un context processor ce qui va permettre aussi en généralisant de simplifier toute les autres vues qui ont besoin de cela.  